### PR TITLE
Iow 595 - Graph server times out when trying to render an image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/usgs/wdfn-graph-server/0.33.0...master)
+### Fixed
+-   Added additional required asset loading for the html rendered by puppeteer. 
 
 ## [0.33.0](https://github.com/usgs/wdfn-graph-server/0.33.0) - 2020-08-17
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wdfn-graph-server",
-  "version": "0.33.0dev",
+  "version": "0.34.0dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -47,7 +47,6 @@ const renderToResponse = function (res,
                         <script>
                             var CONFIG = {
                                 SERVICE_ROOT: '${SERVICE_ROOT}',
-                                NWIS_INVENTORY_ENDPOINT: '',
                                 PAST_SERVICE_ROOT: '${PAST_SERVICE_ROOT}',
                                 MULTIPLE_TIME_SERIES_METADATA_SELECTOR_ENABLED: false,
                                 STATIC_URL: '${STATIC_ROOT}'

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -47,12 +47,14 @@ const renderToResponse = function (res,
                         <script>
                             var CONFIG = {
                                 SERVICE_ROOT: '${SERVICE_ROOT}',
+                                NWIS_INVENTORY_ENDPOINT: '',
                                 PAST_SERVICE_ROOT: '${PAST_SERVICE_ROOT}',
                                 MULTIPLE_TIME_SERIES_METADATA_SELECTOR_ENABLED: false,
                                 STATIC_URL: '${STATIC_ROOT}'
                             };
                         </script>
                         <link rel="stylesheet" href="${STATIC_ROOT}/main.css">
+                        <script src="${STATIC_ROOT}/scripts/vendor.js"></script>
                         <script src="${STATIC_ROOT}/bundle.js"></script>
                     </head>
                     <body id="monitoring-location-page-container">


### PR DESCRIPTION
…ue to the way the code was refactored in waterdataui), Leaflet is needed and it couldn't be found. It might be worthwhile to figure out why but this is a quick fix and probably should be done because the vendor.js file is part of the monitoring location page assets.

Before making a pull request
----------------------------

-   [X] Make sure all tests run
-   [X] Run the npm run lint command locally and verify that your code passes.
-   [X] Update the changelog appropriately
