### PR TITLE
Iow 534 wdfn graph server update puppeteer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Added WATERWATCH_ENDPOINT to application. It defaults to the service url so no changes to Dockerfile needed.
 
+### Changed
+- Updated Puppeteer to version 5.3.1
+
 ## [0.35.0](https://github.com/usgs/wdfn-graph-server/compare/wdfn-graph-server-0.34.0...wdfn-graph-server-0.35.0) - 2020-08-25
 ### Fixed
 - OGC_SITE_ENDPOINT in Dockerfile is now set for the correct OGC endpoint.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use LTS release
-FROM node:12-slim
+FROM node:14.1.0
 
 RUN  apt-get update \
     && apt-get install -y gnupg1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use LTS release
-FROM node:14.1.0
+FROM node:14-slim
 
 RUN  apt-get update \
     && apt-get install -y gnupg1 \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Nation graphs.
 ```/api-docs```
 
 ### Status service
-`/status```
+```/status```
 Returns json object containing the  version of the running service
 
 ### Monitoring Location service  
@@ -29,6 +29,24 @@ The dependencies need to be installed. To clear out any existing dependencies an
 % npm run clean
 % npm install
 ```
+The default port will be 2929 and the base of the URL will start with api/graph-images.
+```bash
+Example - local URL base
+localhost:2929/api/graph-images/
+
+Example - a query that will return a graph for 'depth to water level, feet below land surface' at USGS monitoring location 354133082042203
+http://localhost:2929/api/graph-images/monitoring-location/354133082042203/?parameterCode=72019
+
+
+```
+## Swagger
+Swagger is a application that programmatically generates documentation. Using the generated documentation, you can 
+create various URLs which can be used to test the application or generate graphs. 
+```bash
+Example - local URL for Swagger Documentation
+http://localhost:2929/api/graph-images/api-docs
+
+```  
 
 The swagger json needs to be generated prior to running. If one of the convenience commands
 below are used, the swagger json file is generated before the express server starts. If you want
@@ -86,7 +104,8 @@ You can run eslint against your javascript code using
 ## Docker
 
 For deployment, a docker image is built and then deployed. To mimic the same thing locally execute the following
-from the root level of this repo:
+from the root level of this repo (note: by default, the Docker container uses the same port as the local server,
+ so shut down the local version before running):
 ```bash
 % docker build -t wdfn_graph_server ./
 % docker run -p 2929:2929 --privileged wdfn_graph_server

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ last seven days. The query parameter parameterCode is required and should be a v
 See the OpenAPI documentation for the current list of available list of query parameters
 
 ## Running the server for development
+#### IMPORTANT! You will need version 14.1.0 or higher of Node.js. 
+Lower versions of Node will not unzip the internal Chromium package 
+correctly and this will cause the graph server to 'hang' while it attempts to access a file that it will never find.
+
+
 The dependencies need to be installed. To clear out any existing dependencies and to install:
 ```bash
 % npm run clean

--- a/package-lock.json
+++ b/package-lock.json
@@ -1856,9 +1856,9 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -2571,6 +2571,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "devtools-protocol": {
+      "version": "0.0.799653",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.799653.tgz",
+      "integrity": "sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg=="
     },
     "diff-sequences": {
       "version": "26.5.0",
@@ -3696,17 +3701,17 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "requires": {
             "pump": "^3.0.0"
           }
@@ -3818,7 +3823,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -4221,11 +4225,11 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -6235,7 +6239,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
@@ -6812,7 +6815,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -6821,7 +6823,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       }
@@ -6829,8 +6830,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -6891,8 +6891,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -6967,7 +6966,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       }
@@ -7100,14 +7098,15 @@
       }
     },
     "puppeteer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-3.3.0.tgz",
-      "integrity": "sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.3.1.tgz",
+      "integrity": "sha512-YTM1RaBeYrj6n7IlRXRYLqJHF+GM7tasbvrNFx6w1S16G76NrPq7oYFKLDO+BQsXNtS8kW2GxWCXjIMPvfDyaQ==",
       "requires": {
         "debug": "^4.1.0",
+        "devtools-protocol": "0.0.799653",
         "extract-zip": "^2.0.0",
         "https-proxy-agent": "^4.0.0",
-        "mime": "^2.0.3",
+        "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^3.0.2",
@@ -7117,17 +7116,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "ms": {
           "version": "2.1.2",
@@ -8355,11 +8349,11 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
-      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,9 +3037,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
-      "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-15.0.0.tgz",
+      "integrity": "sha512-MZ8KRhUJLtMbjQo9PsEzFG29vqbQJfLoLBHrTaAaFMtDx9PIm1GZgyUanOLgf1xOE1aWrtZZSbxBYCy8dJCCBg==",
       "dev": true
     },
     "eslint-import-resolver-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3331,9 +3331,9 @@
       "dev": true
     },
     "eslint-plugin-standard": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
-      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.2.tgz",
+      "integrity": "sha512-nKptN8l7jksXkwFk++PhJB3cCDTcXOEyhISIN86Ue2feJ1LFyY3PrY3/xT2keXlJSY5bpmbiTG0f885/YKAvTA==",
       "dev": true
     },
     "eslint-scope": {
@@ -8240,9 +8240,9 @@
       }
     },
     "swagger-jsdoc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-4.3.0.tgz",
-      "integrity": "sha512-hR8DRt5JYguoXhZ0PeFR0dCqtMAr1yc5GIb6pu7HzZqcy/BYfSNdIDn9S1muhyDDRRc5K3g8nHEs3PjdhvSUzg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-4.3.1.tgz",
+      "integrity": "sha512-oRp8uQEWQPnH/WSWgbZYJpsWEYF62V2rQiTHSUGo8x07E0cJYffXu5z1lCKx/PpBoJzrui1xeuqRX6OzhDxZtA==",
       "dev": true,
       "requires": {
         "commander": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.2",
     "jest": "^26.6.0",
     "node-mocks-http": "^1.9.0",
     "nodemon": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "node-mocks-http": "^1.9.0",
     "nodemon": "^2.0.6",
     "npm-run-all": "^4.1.5",
-    "swagger-jsdoc": "^4.3.0"
+    "swagger-jsdoc": "^4.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:swagger": "swagger-jsdoc -d src/swagger-def.js -o src/swagger.json"
   },
   "engines": {
-    "node": "14.1.0"
+    "node": "14.14.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "eslint": "^7.11.0",
-    "eslint-config-standard": "^14.1.1",
+    "eslint-config-standard": "^15.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:swagger": "swagger-jsdoc -d src/swagger-def.js -o src/swagger.json"
   },
   "engines": {
-    "node": "12.16.3"
+    "node": "14.1.0"
   },
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "express-cache-headers": "0.1.4",
     "express-validator": "6.6.1",
     "generic-pool": "3.7.1",
-    "puppeteer": "3.3.0",
+    "puppeteer": "5.3.1",
     "swagger-ui-express": "4.1.4"
   },
   "devDependencies": {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -8,7 +8,7 @@ const STATIC_ROOT = process.env.STATIC_ROOT || 'https://waterdata.usgs.gov/nwisw
 const OGC_SITE_ENDPOINT = process.env.OGC_SITE_ENDPOINT || 'https://labs.waterdata.usgs.gov/api/observations/collections/monitoring-locations/items/';
 const WATERWATCH_ENDPOINT = process.env.WATERWATCH_ENDPOINT || 'https://waterwatch.usgs.gov/webservices';
 
-const renderToResponse = function (res,
+const renderToResponse = function(res,
                                    {
                                        siteID,
                                        parameterCode,
@@ -68,11 +68,11 @@ const renderToResponse = function (res,
                     height: width
                 },
                 componentOptions
-            }).then(function (buffer) {
+            }).then(function(buffer) {
                 res.setHeader('Content-Type', 'image/png');
                 res.write(buffer, 'binary');
                 res.end(null, 'binary');
-            }).catch(function (error) {
+            }).catch(function(error) {
                 console.log(error);
                 res.status(500);
                 res.send({

--- a/src/renderer/puppeteer-pool.test.js
+++ b/src/renderer/puppeteer-pool.test.js
@@ -1,25 +1,25 @@
 const createPool = require('./puppeteer-pool');
 
 
-const inUse = function ({ size, available }) {
+const inUse = function({ size, available }) {
     return size - available;
 };
 
-describe('Puppeteer pool', function () {
+describe('Puppeteer pool', function() {
     let pool;
 
-    beforeEach( function () {
+    beforeEach( function() {
         pool = createPool({
             min: 0,
             max: 2
         });
     });
 
-    afterEach(async function () {
+    afterEach(async function() {
         pool.drain().then(() => pool.clear());
     });
 
-    test('create pool', async function () {
+    test('create pool', async function() {
         const instance = await pool.acquire();
         const page = await instance.newPage();
         const viewportSize = await page.viewport();
@@ -29,9 +29,9 @@ describe('Puppeteer pool', function () {
         await pool.release(instance);
     });
 
-    test('use', async function () {
+    test('use', async function() {
         expect(inUse(pool)).toEqual(0);
-        const result = await pool.use(async function (instance) {
+        const result = await pool.use(async function(instance) {
             expect(inUse(pool)).toEqual(1);
             const page = await instance.newPage();
             return await page.evaluate('navigator.userAgent');
@@ -40,9 +40,9 @@ describe('Puppeteer pool', function () {
         expect(inUse(pool)).toEqual(0);
     });
 
-    test('use and throw', async function () {
+    test('use and throw', async function() {
         expect(inUse(pool)).toEqual(0);
-        await expect(pool.use(async function () {
+        await expect(pool.use(async function() {
                 expect(inUse(pool)).toEqual(1);
                 throw new Error('some err');
             })).rejects.toThrow('some err');

--- a/src/renderer/render-png.js
+++ b/src/renderer/render-png.js
@@ -73,7 +73,7 @@ async function getPNG({pageContent, viewportSize, componentOptions}) {
         // If the page should have a comparison series, wait for it. Otherwise,
         // wait for the current year series. Fall back to the no-data-message
         const chartSel = componentOptions.compare ? '#ts-compare-group' : '#ts-current-group';
-        await page.waitForSelector(`${chartSel}, #no-data-message`);
+        await page.waitForSelector(`${chartSel}, #no-data-message`, { timeout: 100000, visible: true });
 
         // Get a snapshot of either the graph or the no data message, if the
         // graph isn't visible

--- a/src/renderer/render-png.js
+++ b/src/renderer/render-png.js
@@ -32,7 +32,6 @@ const pool = createPuppeteerPool({
     // Arguments to pass on to Puppeteer
     puppeteerArgs: {
         headless: true,
-        executablePath: process.env.CHROME_BIN,
         args: [
             // Ignore CORS issues
             '--disable-web-security',
@@ -56,7 +55,7 @@ async function renderToPage(renderFunc) {
 }
 
 async function getPNG({pageContent, viewportSize, componentOptions}) {
-    return await renderToPage(async function (page) {
+    return await renderToPage(async function(page) {
         // Set the origin header for outgoing requests - this is to avoid waterservices
         // returning a 403 on a null origin.
         page.setExtraHTTPHeaders({


### PR DESCRIPTION
Before making a pull request
----------------------------

-   [x] Make sure all tests run
-   [x] Run the npm run lint command locally and verify that your code passes.
-   [x] Update the changelog appropriately

Description
-----------
This updates Puppeteer to the most recent version. 

So . . . after much  go around, the issue that was preventing Puppeteer from working was that the internal browser was not available to the application. Digging into Node_modules folder showed that the file was in the correct location, but it was failing to be unzipped.  Since the file was not available to the application in the expected format, the application attempted to reach the file over and over again causing to it to fall into an endless loop until the process was stopped with a timeout error from the browser. 

Once the issue was known, I was able to do an internet search for the solution and found https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-is-downloaded-but-fails-to-launch-on-nodejs-14 . This indicated that there was an issue with version 14xx of node and the solution was to use version 14.1.0. 

The application was using version 12.16.3 with the highest long term support version of node currently at 12.19.0. So it is surprising that the solution was to use a 'beta' version. However, that was indeed the solution. 

Using node 14.1.0 allowed for the successful updating of all dependencies including Puppeteer. 

After the dependencies were updated, I tested the Docker container version of the application, and it now runs successfully as well. 


After making a pull request
---------------------------

-   [ ] If appropriate, put the link to the PR in the JIRA ticket
-   [ ] Assign someone to review unless the change is trivial