### PR TITLE
IOW-717 change ecs_pipeline to latest stable version

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -1,4 +1,4 @@
-@Library(value='iow-ecs-pipeline@master', changelog=false) _
+@Library(value='iow-ecs-pipeline@2.2.2', changelog=false) _
 
 pipeline {
     agent {


### PR DESCRIPTION
Before making a pull request
----------------------------

-   [ ] Make sure all tests run
-   [ ] Run the npm run lint command locally and verify that your code passes.
-   [ ] Update the changelog appropriately

Description
-----------
The latest version of the ecs pipeline is on 'master'.  It includes experimental changes to get fargate to work with EFS, which is needed for geoserver.  Other services don't need this, so roll back to latest stable tag (2.2.2)

After making a pull request
---------------------------

-   [ ] If appropriate, put the link to the PR in the JIRA ticket
-   [ ] Assign someone to review unless the change is trivial